### PR TITLE
add api-key gated delete operation

### DIFF
--- a/src/app.py
+++ b/src/app.py
@@ -29,6 +29,13 @@ def get_document(document_id: UUID) -> Article:
     """ Return the metadata for the given document """
     return Article.from_db_article(db.get_article(document_id, None, False))
 
+@prefix_router.delete("/documents/{document_id}")
+def delete_document(document_id: UUID, x_api_key: Optional[str] = Header(None)):
+    """ Delete an article. Requires a write-enabled API key """
+    to_delete = db.get_article(document_id, x_api_key)
+    db.delete_article(document_id, x_api_key)
+    PdfOperator(to_delete).delete()
+
 
 @prefix_router.get("/documents/{document_id}/content")
 def get_document_contents(document_id: UUID, x_api_key: Optional[str] = Header(None)) -> RedirectResponse:

--- a/src/db/db_models.py
+++ b/src/db/db_models.py
@@ -44,6 +44,7 @@ class DbApiKey(Base):
     id = Column(UUID(as_uuid=True), primary_key=True, default=uuid4)
     api_key = Column(String, unique=True)
     enabled = Column(Boolean, default=True)
+    write_enabled = Column(Boolean, default=False) # Whether the API key enables put/post/delete operations
 
 
 

--- a/src/pdf/pdf_operations.py
+++ b/src/pdf/pdf_operations.py
@@ -63,6 +63,10 @@ class PdfOperator:
 
         return get_presigned_url(self.article.bucket_name, self.dest_path)
 
+    def delete(self) -> str:
+        """ Delete the PDF from S3 """
+        delete_object(self.article.bucket_name, self.source_path)
+
 
 class PdfPageOperator(PdfOperator):
     """ PdfOperator that extracts a single page from the source PDF """

--- a/src/s3/s3_client.py
+++ b/src/s3/s3_client.py
@@ -24,3 +24,6 @@ def put_object(bucket: str, path: str, body):
     """ Put an s3 object in the given bucket at the given path """
     return s3.put_object(Bucket=bucket, Key=path, Body=body)
 
+def delete_object(bucket: str, path: str):
+    """ Delete an object from S3 """
+    s3.delete_object(Bucket=bucket, Key=path)


### PR DESCRIPTION
- Add a new column to the API key table for "is allowed to modify the database"
- Add a new api-key gated endpoint 

Relying solely on API-key based security for DB modification permissions is a little bit lax, we will likely want to reconsider this in the future